### PR TITLE
Fix apply

### DIFF
--- a/JsonPatch/Apply.cs
+++ b/JsonPatch/Apply.cs
@@ -68,7 +68,14 @@ namespace JiRangGe.JsonPatch
                     if (jToken is JArray)
                     {
                         JArray item = (JArray)jToken;
-                        item.Insert(Convert.ToInt32(token), value);
+                        if (token == "-")
+                        {
+                            item.Insert(item.Count, value);
+                        }
+                        else
+                        {
+                            item.Insert(Convert.ToInt32(token), value);
+                        }
                     }
                     else
                     {

--- a/JsonPatch/JsonPatch.csproj
+++ b/JsonPatch/JsonPatch.csproj
@@ -30,9 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -52,9 +51,7 @@
     <Compile Include="Utils.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/JsonPatch/packages.config
+++ b/JsonPatch/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="11.0.1-beta1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
 </packages>

--- a/JsonPatchTests/ApplyTests.cs
+++ b/JsonPatchTests/ApplyTests.cs
@@ -26,6 +26,12 @@ namespace JiRangGe.JsonPatch.Tests
             ExpectedResult = "{\"foo\":[\"bar\",{\"foo\":\"bar\"}]}",
             TestName = "Add method works for a simple array path")]
 
+        [TestCase(
+            "{\"foo\":[\"bar\"]}",
+            "[{op: 'add', path: '/foo/-', value: ['abc', 'def']}]",
+            ExpectedResult = "{\"foo\":[\"bar\",[\"abc\",\"def\"]]}",
+            TestName = "Adding an array value")]
+
         public string AddTest(string targetString, string patchDocument)
         {
             JToken target = JToken.Parse(targetString);

--- a/JsonPatchTests/JsonPatchTests.csproj
+++ b/JsonPatchTests/JsonPatchTests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.13.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.1\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -17,7 +18,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>5955b907</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,15 +39,31 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.TestPlatform.AdapterUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.TestPlatform.AdapterUtilities.16.9.1\lib\netstandard1.0\Microsoft.TestPlatform.AdapterUtilities.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.2.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.2.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.13.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.13.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -92,9 +110,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>Данный проект ссылается на пакеты NuGet, отсутствующие на этом компьютере. Используйте восстановление пакетов NuGet, чтобы скачать их.  Дополнительную информацию см. по адресу: http://go.microsoft.com/fwlink/?LinkID=322105. Отсутствует следующий файл: {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.13.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.1\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/JsonPatchTests/packages.config
+++ b/JsonPatchTests/packages.config
@@ -1,7 +1,39 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="11.0.1-beta1" targetFramework="net45" />
-  <package id="NUnit" version="3.9.0" targetFramework="net45" />
-  <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net45" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
+  <package id="Microsoft.TestPlatform.AdapterUtilities" version="16.9.1" targetFramework="net45" />
+  <package id="MSTest.TestFramework" version="2.2.1" targetFramework="net45" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
+  <package id="NUnit" version="3.13.1" targetFramework="net45" />
+  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net45" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net45" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
* Updated packages

* Added one more case from [RFC 6902](https://tools.ietf.org/html/rfc6902). Now it works with paths including '-'.

```text
 An example target JSON document:

   { "foo": ["bar"] }

   A JSON Patch document:

   [
     { "op": "add", "path": "/foo/-", "value": ["abc", "def"] }
   ]

   The resulting JSON document:

   { "foo": ["bar", ["abc", "def"]] }
```